### PR TITLE
天気アイコン表示機能を追加

### DIFF
--- a/go-weather/main.go
+++ b/go-weather/main.go
@@ -7,10 +7,10 @@ import (
 
 func main() {
     weatherData := map[string]string{
-        "tokyo":   "晴れ",
-        "osaka":   "曇り",
-        "sapporo": "雪",
-        "fukuoka": "雨",
+        "tokyo":   "晴れ ☀️",
+        "osaka":   "曇り ☁️",
+        "sapporo": "雪 ❄️",
+        "fukuoka": "雨 🌧️",
     }
 
     fmt.Print("都市名をカンマ区切りで入力してください: ")


### PR DESCRIPTION
ユーザーが天気を見やすくなるように
天気ごとにアイコンを追加しました。

入力例: Tokyo, Osaka
出力例:
Tokyoの天気: 晴れ ☀️
Osakaの天気: 曇り ☁️
